### PR TITLE
refactor: remove unused deleteStockItem repository method

### DIFF
--- a/app/app/src/main/java/com/lojasocial/app/repository/product/StockItemRepository.kt
+++ b/app/app/src/main/java/com/lojasocial/app/repository/product/StockItemRepository.kt
@@ -58,20 +58,7 @@ class StockItemRepository @Inject constructor(
         }
     }
 
-    /**
-     * Deletes a stock item from the items collection
-     * @param stockItemId The ID of the stock item to delete
-     * @return Boolean indicating success or failure
-     */
-    suspend fun deleteStockItem(stockItemId: String): Boolean {
-        return try {
-            itemsCollection.document(stockItemId).delete().await()
-            true
-        } catch (e: Exception) {
-            false
-        }
-    }
-
+    
     /**
      * Get items expiring within the specified number of days (including already expired items)
      * @param daysThreshold Number of days to check ahead (default: 3)

--- a/app/app/src/main/java/com/lojasocial/app/ui/stock/DeleteStockView.kt
+++ b/app/app/src/main/java/com/lojasocial/app/ui/stock/DeleteStockView.kt
@@ -51,7 +51,7 @@ import com.lojasocial.app.ui.theme.ScanRed
 import com.lojasocial.app.ui.theme.LojaSocialPrimary
 import com.lojasocial.app.utils.AppConstants
 import com.lojasocial.app.viewmodel.DeleteStockViewModel
-import com.lojasocial.app.viewmodel.DeleteStockUiState
+import com.lojasocial.app.ui.state.DeleteStockUiState
 import com.lojasocial.app.domain.product.ProductCategory
 import androidx.compose.ui.layout.ContentScale
 import coil.compose.AsyncImage


### PR DESCRIPTION
Removes the deprecated deleteStockItem function from StockItemRepository as it is no longer used by the application logic. Deletes the function definition from StockItemRepository.kt and updates the import of DeleteStockUiState to reflect its new location in the state package.